### PR TITLE
feature: support more mcp server tools and rename some tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Go Build
+name: Go Check
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,3 +18,4 @@ jobs:
       with:
         go-version: '1.25'
     - run: go build ./mcpgo/mcp.go
+    - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -14,15 +14,12 @@ Try the pre-release version in [vscode extension](https://marketplace.visualstud
 
 ## Feature
 
-Current project provides a MCP server with several mcp tools. More tools will be supported later.
-HTTP streamable transport is supported now only.
-
-- [x] go: report go bin, go root and go version.
-- [x] stdlib_symbols: reports all std packages of the global go with all exported symbol details.
-- [ ] external_modules: get all referenced modules with their versions.
-- [ ] module_symbols: get all symbols from a specific version module.
-- [ ] all_modules_symbols: get all symbols from all imported modules.
-
+- [x] go_info: reports the Go environment, including GOROOT, GOBIN, and Go version.
+- [x] go_package_symbols: report all exported symbols of a given content for current project
+- [x] go_std_packages_symbols: reports all std packages of the global go with all exported symbol details.
+- [x] go_std_packages: report all available std packages with their docs, if see all symbols inside it, use go_std_packages_symbols
+- [x] project_used_modules: reports all modules used in the current project with their versions, it respects all possible go mod directives like replace.
+- [x] project_defined_packages: reports all pacakges defined by current project with their docs
 
 ## Motivation
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xieyuschen/go-mcp-server
 go 1.25.0
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/modelcontextprotocol/go-sdk v0.6.0
 	golang.org/x/tools v0.34.0
 )

--- a/internal/tool/generate.go
+++ b/internal/tool/generate.go
@@ -1,0 +1,23 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/xieyuschen/go-mcp-server/internal/tool"
+)
+
+func main() {
+	readme := "../../README.md"
+	bs, err := os.ReadFile(readme)
+	if err != nil {
+		panic(err)
+	}
+
+	newBytes := tool.UpdateReadme(string(bs))
+	err = os.WriteFile(readme, []byte(newBytes), 0666)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/internal/tool/handler_test.go
+++ b/internal/tool/handler_test.go
@@ -1,0 +1,21 @@
+package tool
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDocs(t *testing.T) {
+	bs, err := os.ReadFile("../../README.md")
+	if err != nil {
+		panic(err)
+	}
+
+	newBytes := UpdateReadme(string(bs))
+
+	if diff := cmp.Diff(string(bs), newBytes); diff != "" {
+		t.Fatalf("generated readme and current readme is different, consider to run 'go generate ./...'. Diff: %s", diff)
+	}
+}

--- a/internal/tool/model.go
+++ b/internal/tool/model.go
@@ -1,0 +1,67 @@
+package tool
+
+// ===== Input ====
+type IEmpty struct{}
+
+type IUsedModules struct {
+	Cwd string `json:"cwd" jsonschema:"the current working directory to find the go.mod file"`
+}
+
+type IGoProjectPackage struct {
+	Cwd         string `json:"cwd" jsonschema:"the current working directory to find the go.mod file"`
+	PackagePath string `json:"package_path" jsonschema:"imported package path in current project"`
+}
+
+// ===== Output ====
+type OGoInfo struct {
+	Version string `json:"version" jsonschema:"the Go version"`
+	GoBin   string `json:"gobin" jsonschema:"the GOBIN environment variable"`
+	GOROOT  string `json:"goroot" jsonschema:"the GOROOT environment variable"`
+}
+
+type OStdlibSymbols struct {
+	StdLibs map[string]Package `json:"stdlibs" jsonschema:"the Go standard libraries"`
+}
+
+type OProjectUsedModules struct {
+	Modules []Module `json:"modules" jsonschema:"the used modules"`
+}
+
+type OProjectDefinedPackages struct {
+	Packages map[string]Package `json:"packages" jsonschema:"packages under current project"`
+}
+
+type OGoPackage struct {
+	Package Package `json:"package" jsonschema:"all exported symbols of a given package based on current project go.mod."`
+}
+
+// ===== Output Structures ====
+
+type Module struct {
+	Path    string `json:"path" jsonschema:"the module path"`
+	Version string `json:"version" jsonschema:"the module version"`
+	// todo: consider whether and how to support Replace field.
+	// Replace   *Module    `json:"replace" jsonschema:"replaced by this module"`
+	Main      bool   `json:"main" jsonschema:"is this the main module?"`
+	Indirect  bool   `json:"indirect" jsonschema:"is this module only an indirect dependency of main module?"`
+	Dir       string `json:"dir" jsonschema:"directory holding files for this module, if any"`
+	GoMod     string `json:"go_mod" jsonschema:"path to go.mod file used when loading this module, if any"`
+	GoVersion string `json:"go_version" jsonschema:"go version used in module"`
+}
+
+type Symbol struct {
+	Name     string           `json:"name" jsonschema:"the name of the symbol"`
+	Detail   string           `json:"detail" jsonschema:"the detail of the symbol, e.g., the signature of a function"`
+	Kind     filedKind        `json:"kind" jsonschema:"the kind of the symbol, e.g., function, type, variable, constant"`
+	Doc      string           `json:"doc" jsonschema:"the documentation of the symbol"`
+	Children []DocumentSymbol `json:"children,omitempty" jsonschema:"the child symbols of the symbol"`
+}
+
+type Package struct {
+	Name          string   `json:"name" jsonschema:"the name of the symbol"`
+	ModuleName    string   `json:"module" jsonschema:"the associated module of a package"`
+	ModuleVersion string   `json:"module_version" jsonschema:"the associated module version of a package"`
+	Path          string   `json:"path" jsonschema:"the import path of a package"`
+	Docs          string   `json:"docs" jsonschema:"the documentation of a package"`
+	Symbols       []Symbol `json:"symbols" jsonschema:"the symbols in a package"`
+}


### PR DESCRIPTION
This commit has aggregated tools together in an array, so we can better manage them. The documentation is also generated by 'go generate ./...'

New test is added to ensure the docs is always up-to-date.

New added tools are:

- go_package_symbols
- project_used_modules
- project_defined_packages
- go_std_packages

Existing tools are renamed to make them clearer.

- stdlib_symbols -> go_std_packages_symbols