### PR TITLE
improve: add start,end position and file path in symbols

### DIFF
--- a/internal/tool/model.go
+++ b/internal/tool/model.go
@@ -49,19 +49,26 @@ type Module struct {
 	GoVersion string `json:"go_version" jsonschema:"go version used in module"`
 }
 
+type Pos struct {
+	Filename string `json:"filename" jsonschema:"the filename of current position"`
+	Offset   int    `json:"offset" jsonschema:"the line of current position, offset, starting at 0"`
+	Line     int    `json:"line" jsonschema:"line number, starting at 1"`
+	Column   int    `json:"column" jsonschema:"column number, starting at 1 (byte count)"`
+}
+
 type Symbol struct {
-	Name     string           `json:"name" jsonschema:"the name of the symbol"`
-	Detail   string           `json:"detail" jsonschema:"the detail of the symbol, e.g., the signature of a function"`
-	Kind     filedKind        `json:"kind" jsonschema:"the kind of the symbol, e.g., function, type, variable, constant"`
-	Doc      string           `json:"doc" jsonschema:"the documentation of the symbol"`
-	Children []DocumentSymbol `json:"children,omitempty" jsonschema:"the child symbols of the symbol"`
+	ShortSymbol
+	FilePath string `json:"file_path" jsonschema:"the symbol's file path"`
+	Doc      string `json:"doc,omitempty" jsonschema:"the documentation of the symbol"`
+	Start    Pos    `json:"start" jsonschema:"the place this symbol starts"`
+	End      Pos    `json:"end" jsonschema:"the place this symbol ends"`
 }
 
 type Package struct {
 	Name          string   `json:"name" jsonschema:"the name of the symbol"`
-	ModuleName    string   `json:"module" jsonschema:"the associated module of a package"`
-	ModuleVersion string   `json:"module_version" jsonschema:"the associated module version of a package"`
 	Path          string   `json:"path" jsonschema:"the import path of a package"`
-	Docs          string   `json:"docs" jsonschema:"the documentation of a package"`
-	Symbols       []Symbol `json:"symbols" jsonschema:"the symbols in a package"`
+	ModuleName    string   `json:"module,omitempty" jsonschema:"the associated module of a package"`
+	ModuleVersion string   `json:"module_version,omitempty" jsonschema:"the associated module version of a package"`
+	Docs          string   `json:"docs,omitempty" jsonschema:"the documentation of a package"`
+	Symbols       []Symbol `json:"symbols,omitempty" jsonschema:"the symbols in a package"`
 }

--- a/internal/tool/util.go
+++ b/internal/tool/util.go
@@ -49,8 +49,15 @@ func getPackageInfo(pkg *packages.Package, ignoreSymbols bool) Package {
 					continue
 				}
 
-				sym := funcSymbol(decl)
-				sym.Doc = decl.Doc.Text()
+				shortSym := funcSymbol(decl)
+				start, end := Position(tok, decl.Pos()), Position(tok, decl.End())
+				sym := Symbol{
+					ShortSymbol: shortSym,
+					Doc:         decl.Doc.Text(),
+					Start:       Pos(start),
+					End:         Pos(end),
+					FilePath:    file.Name.Name,
+				}
 				symbols = append(symbols, sym)
 			case *ast.GenDecl:
 				for _, spec := range decl.Specs {
@@ -59,17 +66,31 @@ func getPackageInfo(pkg *packages.Package, ignoreSymbols bool) Package {
 						if spec.Name.Name == "_" || !ast.IsExported(spec.Name.Name) {
 							continue
 						}
-						sym := typeSymbol(tok, spec)
-						sym.Doc = decl.Doc.Text()
+						shortSym := typeSymbol(tok, spec)
+						start, end := Position(tok, decl.Pos()), Position(tok, decl.End())
+						sym := Symbol{
+							ShortSymbol: shortSym,
+							Doc:         decl.Doc.Text(),
+							Start:       Pos(start),
+							End:         Pos(end),
+							FilePath:    file.Name.Name,
+						}
 						symbols = append(symbols, sym)
 					case *ast.ValueSpec:
 						for _, name := range spec.Names {
 							if name.Name == "_" || !ast.IsExported(name.Name) {
 								continue
 							}
-							vs := varSymbol(tok, spec, name, decl.Tok == token.CONST)
-							vs.Doc = decl.Doc.Text()
-							symbols = append(symbols, vs)
+							shortSym := varSymbol(tok, spec, name, decl.Tok == token.CONST)
+							start, end := Position(tok, decl.Pos()), Position(tok, decl.End())
+							sym := Symbol{
+								ShortSymbol: shortSym,
+								Doc:         decl.Doc.Text(),
+								Start:       Pos(start),
+								End:         Pos(end),
+								FilePath:    file.Name.Name,
+							}
+							symbols = append(symbols, sym)
 						}
 					}
 				}

--- a/mcpgo/mcp.go
+++ b/mcpgo/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/xieyuschen/go-mcp-server/internal/tool"
@@ -23,6 +24,9 @@ func init() {
 }
 
 func main() {
+	// write to stdout rather than stderr otherwise vscode plugin complains.
+	log.SetOutput(os.Stdout)
+
 	// Create a server with a single tool.
 	server := mcp.NewServer(&mcp.Implementation{Name: mcpName, Version: mcpVersion}, nil)
 


### PR DESCRIPTION
This commit also changes logger output to stdout to avoid misleading error log during vscode extension starts.